### PR TITLE
Iobufcnt 2017.08.21.00

### DIFF
--- a/folly/io/IOBuf.h
+++ b/folly/io/IOBuf.h
@@ -237,7 +237,8 @@ class IOBuf {
 
   static std::atomic<uint64_t> bufUsage_;
   static uint64_t getBufUsage();
-  static void incrementUsage(uint64_t dataLen);
+  void incrementUsage(uint64_t dataLen);
+  uint16_t getHeapPrefix();
   static void decrementUsage(uint64_t dataLen);
 
   /**

--- a/folly/io/IOBuf.h
+++ b/folly/io/IOBuf.h
@@ -235,6 +235,11 @@ class IOBuf {
 
   typedef void (*FreeFunction)(void* buf, void* userData);
 
+  static std::atomic<uint64_t> bufUsage_;
+  static uint64_t getBufUsage();
+  static void incrementUsage(uint64_t dataLen);
+  static void decrementUsage(uint64_t dataLen);
+
   /**
    * Allocate a new IOBuf object with the requested capacity.
    *


### PR DESCRIPTION
1. add incrementUsage / decrementUsage to count iobuf alloc / dealloc in realtime
2.  hedvig will call incrementUsage for every iobuf he allocates and the iobuf passed from proxygen side, and decrementUsage will be called at time of destruction of iobuf.
3. since proxygen has its own iobuf which hedvig isnt aware of, putting the decrement counter in all destructor will be accounted for those iobuf that hedvig isnt aware of. Therefore in incrementUsage for every iobuf, we utilize some of the field iobuf underlying structure provides, the HeapStorage struct, where it has a HeapPrefix struct which contains a flag named magic, so we mark this field with hedvig flag, indicating its a hedvig aware iobuf and decrement it if necessary.
4. Found almost all iobuf allocates without the HeapPrefix struct (since we heavily uses IOBuf::createSeparate instead of IOBuf::createCombined to optimize the mem utilization) so directly mark the SharedInfo.userData void ptr with uint16_t*